### PR TITLE
Create folder before copy kaggle secret

### DIFF
--- a/nbs/Connect_Kaggle_to_Colab.ipynb
+++ b/nbs/Connect_Kaggle_to_Colab.ipynb
@@ -143,6 +143,7 @@
    },
    "outputs": [],
    "source": [
+    "!mkdir /root/.kaggle\n",
     "!cp kaggle.json /root/.kaggle/"
    ]
   },


### PR DESCRIPTION
Create the folder to avoid a cp error.
`cp: cannot create regular file '/root/.kaggle/': Not a directory`